### PR TITLE
➕ Updating linter config to tslint

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,11 +11,11 @@ First install the config
 > npm install TwinePlatform/eslint-config-twine
 ```
 
-Then add an `.eslintrc` file that extends the config:
+Then add an `tslint.json` file that extends the config:
 
 ```
 {
-  "extends": "twine"
+    "extends": "eslint-config-twine"
 }
 ```
 

--- a/index.js
+++ b/index.js
@@ -1,19 +1,9 @@
 module.exports = {
   "extends": "tslint-config-airbnb",
-  "env": {
-    "node": true,
-    "jest": true
-  },
   "rules": {
-    "semi": [ "error", "always" ],
-    "brace-style": [ "error", "1tbs" ],
-    "padded-blocks": "off",
-    "comma-dangle": [ "error", "always-multiline" ],
-    "arrow-parens": [ "error", "always" ],
-    "consistent-return": "off",
-    "no-confusing-arrow": "off",
-    "no-shadow": "off",
-    "no-prototype-builtins": "off",
-    "camelcase": "off",
-  }
+    "semicolon": [ true, "always" ],
+    "trailing-comma": [true, {"multiline": "always", "singleline": "never"}],
+    "arrow-parens": true,
+    "no-shadowed-variable": false
+    }
 };

--- a/index.js
+++ b/index.js
@@ -1,5 +1,5 @@
 module.exports = {
-  "extends": "airbnb",
+  "extends": "tslint-config-airbnb",
   "env": {
     "node": true,
     "jest": true

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,29 +1,129 @@
 {
   "name": "eslint-config-twine",
-  "version": "1.0.0",
+  "version": "2.0.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
-    "eslint-config-airbnb": {
-      "version": "16.1.0",
-      "resolved": "https://registry.npmjs.org/eslint-config-airbnb/-/eslint-config-airbnb-16.1.0.tgz",
-      "integrity": "sha512-zLyOhVWhzB/jwbz7IPSbkUuj7X2ox4PHXTcZkEmDqTvd0baJmJyuxlFPDlZOE/Y5bC+HQRaEkT3FoHo9wIdRiw==",
+    "@fimbul/bifrost": {
+      "version": "0.9.0",
+      "resolved": "https://registry.npmjs.org/@fimbul/bifrost/-/bifrost-0.9.0.tgz",
+      "integrity": "sha512-efruzazTrtkipgpC166pSK3fAc+5n55B0wrLbpkO33dO6OJtI0LxP5u89OQV9I3tp6oCOZB2p4+7+CwulVmAkA==",
       "requires": {
-        "eslint-config-airbnb-base": "^12.1.0"
+        "@fimbul/ymir": "^0.9.0",
+        "get-caller-file": "^1.0.2",
+        "tslib": "^1.8.1",
+        "tsutils": "^2.24.0"
       }
     },
-    "eslint-config-airbnb-base": {
-      "version": "12.1.0",
-      "resolved": "https://registry.npmjs.org/eslint-config-airbnb-base/-/eslint-config-airbnb-base-12.1.0.tgz",
-      "integrity": "sha512-/vjm0Px5ZCpmJqnjIzcFb9TKZrKWz0gnuG/7Gfkt0Db1ELJR51xkZth+t14rYdqWgX836XbuxtArbIHlVhbLBA==",
+    "@fimbul/ymir": {
+      "version": "0.9.0",
+      "resolved": "https://registry.npmjs.org/@fimbul/ymir/-/ymir-0.9.0.tgz",
+      "integrity": "sha512-IR3wvH2Lae6ab96CKT68Xj/o8Ozpoq8ifRnxlKmhIqHLSnABaVdJ1Mta3DGyI7wElQQsGQUySkEv/eJiL/AxTg==",
       "requires": {
-        "eslint-restricted-globals": "^0.1.1"
+        "inversify": "^4.10.0",
+        "reflect-metadata": "^0.1.12",
+        "tslib": "^1.8.1"
       }
     },
-    "eslint-restricted-globals": {
-      "version": "0.1.1",
-      "resolved": "https://registry.npmjs.org/eslint-restricted-globals/-/eslint-restricted-globals-0.1.1.tgz",
-      "integrity": "sha1-NfDVy8ZMLj7WLpO0saevBbp+1Nc="
+    "doctrine": {
+      "version": "0.7.2",
+      "resolved": "https://registry.npmjs.org/doctrine/-/doctrine-0.7.2.tgz",
+      "integrity": "sha1-fLhgNZujvpDgQLJrcpzkv6ZUxSM=",
+      "requires": {
+        "esutils": "^1.1.6",
+        "isarray": "0.0.1"
+      }
+    },
+    "esutils": {
+      "version": "1.1.6",
+      "resolved": "https://registry.npmjs.org/esutils/-/esutils-1.1.6.tgz",
+      "integrity": "sha1-wBzKqa5LiXxtDD4hCuUvPHqEQ3U="
+    },
+    "get-caller-file": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/get-caller-file/-/get-caller-file-1.0.2.tgz",
+      "integrity": "sha1-9wLmMSfn4jHBYKgMFVSstw1QR+U="
+    },
+    "inversify": {
+      "version": "4.13.0",
+      "resolved": "https://registry.npmjs.org/inversify/-/inversify-4.13.0.tgz",
+      "integrity": "sha512-O5d8y7gKtyRwrvTLZzYET3kdFjqUy58sGpBYMARF13mzqDobpfBXVOPLH7HmnD2VR6Q+1HzZtslGvsdQfeb0SA=="
+    },
+    "isarray": {
+      "version": "0.0.1",
+      "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
+      "integrity": "sha1-ihis/Kmo9Bd+Cav8YDiTmwXR7t8="
+    },
+    "reflect-metadata": {
+      "version": "0.1.12",
+      "resolved": "https://registry.npmjs.org/reflect-metadata/-/reflect-metadata-0.1.12.tgz",
+      "integrity": "sha512-n+IyV+nGz3+0q3/Yf1ra12KpCyi001bi4XFxSjbiWWjfqb52iTTtpGXmCCAOWWIAn9KEuFZKGqBERHmrtScZ3A=="
+    },
+    "tslib": {
+      "version": "1.9.2",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.9.2.tgz",
+      "integrity": "sha512-AVP5Xol3WivEr7hnssHDsaM+lVrVXWUvd1cfXTRkTj80b//6g2wIFEH6hZG0muGZRnHGrfttpdzRk3YlBkWjKw=="
+    },
+    "tslint-config-airbnb": {
+      "version": "5.9.2",
+      "resolved": "https://registry.npmjs.org/tslint-config-airbnb/-/tslint-config-airbnb-5.9.2.tgz",
+      "integrity": "sha512-7hT9VoPxT64Xk68+Ak4rhHCaVja6jHFIE6koeHCbZTz1XKUUVX4qZTHUZBLVS/0CmuyDJ1U/8ALyqn+gFxZgbQ==",
+      "requires": {
+        "tslint-consistent-codestyle": "^1.10.0",
+        "tslint-eslint-rules": "^5.3.1",
+        "tslint-microsoft-contrib": "~5.0.1"
+      }
+    },
+    "tslint-consistent-codestyle": {
+      "version": "1.13.1",
+      "resolved": "https://registry.npmjs.org/tslint-consistent-codestyle/-/tslint-consistent-codestyle-1.13.1.tgz",
+      "integrity": "sha512-t4BRGtjuejYikhcOrpR8GjaSBrN3lwP9iMlO9vbhA6SCGeJvebfNMLeo7PY2ZhXdwkjdTh0mMWV4zDyLs9FKYg==",
+      "requires": {
+        "@fimbul/bifrost": "^0.9.0",
+        "tslib": "^1.7.1",
+        "tsutils": "^2.27.0"
+      }
+    },
+    "tslint-eslint-rules": {
+      "version": "5.3.1",
+      "resolved": "https://registry.npmjs.org/tslint-eslint-rules/-/tslint-eslint-rules-5.3.1.tgz",
+      "integrity": "sha512-qq2H/AU/FlFbQJKXuxhtIk+ni/nQu9jHHhsFKa6hnA0/n3zl1/RWRc3TVFlL8HfWFMzkST350VeTrFpy1u4OUg==",
+      "requires": {
+        "doctrine": "0.7.2",
+        "tslib": "1.9.0",
+        "tsutils": "2.8.0"
+      },
+      "dependencies": {
+        "tslib": {
+          "version": "1.9.0",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.9.0.tgz",
+          "integrity": "sha512-f/qGG2tUkrISBlQZEjEqoZ3B2+npJjIf04H1wuAv9iA8i04Icp+61KRXxFdha22670NJopsZCIjhC3SnjPRKrQ=="
+        },
+        "tsutils": {
+          "version": "2.8.0",
+          "resolved": "https://registry.npmjs.org/tsutils/-/tsutils-2.8.0.tgz",
+          "integrity": "sha1-AWAXNymzvxOGKN0UoVN+AIUdgUo=",
+          "requires": {
+            "tslib": "^1.7.1"
+          }
+        }
+      }
+    },
+    "tslint-microsoft-contrib": {
+      "version": "5.0.3",
+      "resolved": "https://registry.npmjs.org/tslint-microsoft-contrib/-/tslint-microsoft-contrib-5.0.3.tgz",
+      "integrity": "sha512-5AnfTGlfpUzpRHLmoojPBKFTTmbjnwgdaTHMdllausa4GBPya5u36i9ddrTX4PhetGZvd4JUYIpAmgHqVnsctg==",
+      "requires": {
+        "tsutils": "^2.12.1"
+      }
+    },
+    "tsutils": {
+      "version": "2.27.1",
+      "resolved": "https://registry.npmjs.org/tsutils/-/tsutils-2.27.1.tgz",
+      "integrity": "sha512-AE/7uzp32MmaHvNNFES85hhUDHFdFZp6OAiZcd6y4ZKKIg6orJTm8keYWBhIhrJQH3a4LzNKat7ZPXZt5aTf6w==",
+      "requires": {
+        "tslib": "^1.8.1"
+      }
     }
   }
 }

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "private": true,
   "name": "eslint-config-twine",
-  "version": "1.0.0",
+  "version": "2.0.0",
   "description": "ESLint config for all Twine Projects",
   "main": "index.js",
   "scripts": {
@@ -21,9 +21,9 @@
   },
   "homepage": "https://github.com/TwinePlatform/eslint-config-twine#readme",
   "peerDependencies": {
-    "eslint": "^4.19.1"
+    "tslint": "^5.10.0"
   },
   "dependencies": {
-    "eslint-config-airbnb": "^16.1.0"
+    "tslint-config-airbnb": "^5.9.2"
   }
 }

--- a/package.json
+++ b/package.json
@@ -20,10 +20,11 @@
     "url": "https://github.com/TwinePlatform/eslint-config-twine/issues"
   },
   "homepage": "https://github.com/TwinePlatform/eslint-config-twine#readme",
-  "peerDependencies": {
-    "tslint": "^5.10.0"
-  },
   "dependencies": {
-    "tslint-config-airbnb": "^5.9.2"
+    "tslint-config-airbnb": "^5.9.2",
+    "tslint": "^5.10.0",
+    "tslint-consistent-codestyle": "^1.13.1",
+    "tslint-eslint-rules": "^5.3.1",
+    "tslint-microsoft-contrib": "^5.0.3"
   }
 }


### PR DESCRIPTION
**Changes:**
- update version number
- replace airbnb config with tslint equivalent.

**NB:** There's a number of eslint rules that i couldn't find tslint equivalents for
- `"brace-style": [ "error", "1tbs" ],`
- `"padded-blocks": "off",`
- `"consistent-return": "off",`
- `"no-confusing-arrow": "off",`
- `"no-prototype-builtins": "off",`

Also curious why we have shadowing allowed...

✨ This branch has been tested with `twine-api` repo ✨ 