### PR TITLE
🗜 Allow imports to be named differently to files

### DIFF
--- a/index.js
+++ b/index.js
@@ -18,6 +18,7 @@ module.exports = {
       "esSpecCompliant": true
     }],
     "no-consecutive-blank-lines": [true, 2],
-    "variable-name": [true, "ban-keywords", "check-format", "allow-pascal-case"]
+    "variable-name": [true, "ban-keywords", "check-format", "allow-pascal-case"],
+    'import-name': false
   }
 };

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "private": true,
   "name": "eslint-config-twine",
-  "version": "2.0.1",
+  "version": "2.0.2",
   "description": "ESLint config for all Twine Projects",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
This rule is annoying when you're trying to import index files